### PR TITLE
Fix mac os build

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ You don't have to compile PyNX, you can [just grab a release build](https://gith
 
 Compile PyNX using `make`. This will create a `build` directory and build everything in there. Compiling might take a while, grab a coffee or whatever in the meantime if you like. Afterwards, create a distributable version using `make dist`. It will appear in the `build` directory.
 
+### Mac OS
+You will have to install gnu-sed first(`brew install gnu-sed`).
+
 ## Documentation
 
 Documentation can be found on [ReadTheDocs](https://nx-python.readthedocs.io/en/latest/).

--- a/python_build/Makefile
+++ b/python_build/Makefile
@@ -30,6 +30,13 @@ LIBS	:= -lnx
 # include and lib
 #---------------------------------------------------------------------------------
 
+# Use gnu-sed if it is macos
+ifeq ($(UNAME_S),Darwin)
+	SED := gsed
+else
+	SED := sed
+endif
+
 PYCONFIG_DIR := ../python_config
 
 LIBDIRS	:= $(PORTLIBS) $(LIBNX)
@@ -42,7 +49,7 @@ ifndef PYVERS
 	PYVERS := 3.5.3
 endif
 
-ANAME  := libpython$(shell echo $(PYVERS) | sed 's/\([0-9]*\.\([0-9]*\)\).*/\1/').a
+ANAME  := libpython$(shell echo $(PYVERS) | $(SED) 's/\([0-9]*\.\([0-9]*\)\).*/\1/').a
 
 OUTDIR := nxpy$(PYVERS)
 
@@ -53,6 +60,8 @@ _NXFILE := _nx.zip
 _NXVERS := 5baa28b0ce6ab2c8390fd85cfc36e1086f2cede9
 NXFILE := nx.zip
 NXVERS := e0fb67e90e945c6f214f16a804ae1ca7fa211d95
+
+
 
 .PHONY: all clean
 
@@ -67,7 +76,7 @@ distfPY: linkPY
 	cp $(PYDIR)/Include/* $(OUTDIR)/include/nxpy
 	cp $(PYDIR)/pyconfig.h $(OUTDIR)/include/nxpy/
 	cp $(PYDIR)/Lib/socket.py $(PYDIR)/Lib/socket.pyX
-	cat $(PYDIR)/Lib/socket.pyX | sed 's/'"'"'getpeername'"'"', //g' >$(PYDIR)/Lib/socket.py
+	cat $(PYDIR)/Lib/socket.pyX | $(SED) 's/'"'"'getpeername'"'"', //g' >$(PYDIR)/Lib/socket.py
 	rm $(PYDIR)/Lib/socket.pyX
 	cd $(PYDIR)/Lib && ls *.py -1 | xargs zip ../../$(OUTDIR)/python.zip && find json/ encodings/ html/ http/ test/ urllib/ collections/ email/ sqlite3/ logging/ xml/ importlib/ asyncio/ -type f | xargs zip ../../$(OUTDIR)/python.zip
 
@@ -91,15 +100,15 @@ soospatchPY: compilePY
 	cp $(PYCONFIG_DIR)/fileutils.c $(PYDIR)/Python/
 	cp $(PYCONFIG_DIR)/getaddrinfo.c $(PYDIR)/Modules/
 	cp $(PYDIR)/Modules/posixmodule.c $(PYDIR)/Modules/posixmodule.c_old
-	cat $(PYDIR)/Modules/posixmodule.c_old | sed 's/return utime(path, time)/errno=ENOENT; return -1/g' | sed 's/define LSTAT lstat/define LSTAT stat/' | sed '1s/^/#include <sys\/socket.h>/' | sed 's/access(path->narrow, mode)/1/' | sed 's/\(^[^rt]*time_t atime, mtime;.*\)/return NULL; \1/' | sed 's/\(^[^ri]*int i = (int)umask(mask);.*\)/int i=0; return NULL;/' | sed 's/^\([^#][^#]*#undef HAVE_FSTATVFS.*\)/\#undef HAVE_FSTATVFS \1/' | sed 's/#define HAVE_\(EXECV\|FORK\|GETEGID\|GETEUID\|GETGID\|GETPPID\|GETUID\|KILL\|PIPE\|POPEN\|SYSTEM\|TTYNAME\|SYMLINK\|UTIME_H\|FDATASYNC\).*/#undef HAVE_\1/g' | sed 's/^#define HAVE_\(STATVFS\|SYS_STATVFS_H\|FDATASYNC\|FTIME\|SYMLINK\|EXECV\|FORK\|GETEGID\|GETEUID\|GETGID\|GETPPID\|GETUID\|KILL\|PIPE\|POPEN\|SYSTEM\|TTYNAME\|SYMLINK\|UTIME_H\|FDATASYNC\).*/#undef HAVE_\1/' >$(PYDIR)/Modules/posixmodule.c
+	cat $(PYDIR)/Modules/posixmodule.c_old | $(SED) 's/return utime(path, time)/errno=ENOENT; return -1/g' | $(SED) 's/define LSTAT lstat/define LSTAT stat/' | $(SED) '1s/^/#include <sys\/socket.h>/' | $(SED) 's/access(path->narrow, mode)/1/' | $(SED) 's/\(^[^rt]*time_t atime, mtime;.*\)/return NULL; \1/' | $(SED) 's/\(^[^ri]*int i = (int)umask(mask);.*\)/int i=0; return NULL;/' | $(SED) 's/^\([^#][^#]*#undef HAVE_FSTATVFS.*\)/\#undef HAVE_FSTATVFS \1/' | $(SED) 's/#define HAVE_\(EXECV\|FORK\|GETEGID\|GETEUID\|GETGID\|GETPPID\|GETUID\|KILL\|PIPE\|POPEN\|SYSTEM\|TTYNAME\|SYMLINK\|UTIME_H\|FDATASYNC\).*/#undef HAVE_\1/g' | $(SED) 's/^#define HAVE_\(STATVFS\|SYS_STATVFS_H\|FDATASYNC\|FTIME\|SYMLINK\|EXECV\|FORK\|GETEGID\|GETEUID\|GETGID\|GETPPID\|GETUID\|KILL\|PIPE\|POPEN\|SYSTEM\|TTYNAME\|SYMLINK\|UTIME_H\|FDATASYNC\).*/#undef HAVE_\1/' >$(PYDIR)/Modules/posixmodule.c
 	cp $(PYDIR)/Modules/socketmodule.c $(PYDIR)/Modules/socketmodule.c_old
-	cat $(PYDIR)/Modules/socketmodule.c_old | sed 's/send(s->sock_fd, buf, len, flags);/send(s->sock_fd, buf, len<4096?len:4096, flags);/g' | sed 's/                             sizeof(addr->sa_data)/                             28/g' >$(PYDIR)/Modules/socketmodule.c
+	cat $(PYDIR)/Modules/socketmodule.c_old | $(SED) 's/send(s->sock_fd, buf, len, flags);/send(s->sock_fd, buf, len<4096?len:4096, flags);/g' | $(SED) 's/                             sizeof(addr->sa_data)/                             28/g' >$(PYDIR)/Modules/socketmodule.c
 	cp $(PYDIR)/Objects/exceptions.c $(PYDIR)/Objects/exceptions.c_old
-	cat $(PYDIR)/Objects/exceptions.c_old | sed 's/ESHUTDOWN/EPIPE/g' >$(PYDIR)/Objects/exceptions.c
+	cat $(PYDIR)/Objects/exceptions.c_old | $(SED) 's/ESHUTDOWN/EPIPE/g' >$(PYDIR)/Objects/exceptions.c
 	cp $(PYDIR)/Python/pytime.c $(PYDIR)/Python/pytime.c_old
-	cat $(PYDIR)/Python/pytime.c_old | sed 's/CLOCK_MONOTONIC/(clockid_t)4/g' >$(PYDIR)/Python/pytime.c
+	cat $(PYDIR)/Python/pytime.c_old | $(SED) 's/CLOCK_MONOTONIC/(clockid_t)4/g' >$(PYDIR)/Python/pytime.c
 	cp $(PYDIR)/Makefile $(PYDIR)/Makefile_old
-	cat $(PYDIR)/Makefile_old | sed 's/-Werror=declaration-after-statement//' | sed 's/Python\/$$(DYNLOADFILE) \\/\\/' >$(PYDIR)/Makefile
+	cat $(PYDIR)/Makefile_old | $(SED) 's/-Werror=declaration-after-statement//' | $(SED) 's/Python\/$$(DYNLOADFILE) \\/\\/' >$(PYDIR)/Makefile
 	touch soospatchPY
 
 compilePY: extractedPY patchPY
@@ -107,12 +116,12 @@ compilePY: extractedPY patchPY
 
 patchPY: cloneNX
 	cp $(PYDIR)/configure $(PYDIR)/configure_old
-	cat $(PYDIR)/configure_old | sed 's/	\*\-\*\-linux\*)/	\*\-\*\-linux\*\|aarch64\-none\-elf)/g' >$(PYDIR)/configure
+	cat $(PYDIR)/configure_old | $(SED) 's/	\*\-\*\-linux\*)/	\*\-\*\-linux\*\|aarch64\-none\-elf)/g' >$(PYDIR)/configure
 	echo ac_cv_file__dev_ptmx=no >$(PYDIR)/config.site
 	echo ac_cv_file__dev_ptc=no >>$(PYDIR)/config.site
 	echo ac_cv_lib_dl_dlopen=no >>$(PYDIR)/config.site
 	cp $(PYDIR)/Modules/Setup.dist $(PYDIR)/Modules/Setup.dist_old
-	cat $(PYDIR)/Modules/Setup.dist_old | sed -e '$$a_nx -I$$(srcdir)/Modules/_nx _nx/_nxmodule.c' | sed 's/^\([^#].* pwdmodule\.c.*\)/#\1/' | sed 's/^#\(array\|cmath\|math\|_struct\|operator\|_random\|_collections\|itertools\|signal\|strop\|unicodedata\|_io\|_csv\|_md5\|_sha\|_sha256\|_sha512\|binascii\|select\|cStringIO\|time\|_functools\|_socket\|datetime\|_bisect\)\(.*\)/\1\2/' | sed "s#\\(zlib[^\$$]*\\)\$$(prefix)\\([^\$$]*\\)\$$(exec_prefix)\\(.*\\)#\1$(DEVKITPRO)/portlibs/switch\2$(DEVKITPRO)/portlibs/switch\3#" >$(PYDIR)/Modules/Setup.dist
+	cat $(PYDIR)/Modules/Setup.dist_old | $(SED) -e '$$a_nx -I$$(srcdir)/Modules/_nx _nx/_nxmodule.c' | $(SED) 's/^\([^#].* pwdmodule\.c.*\)/#\1/' | $(SED) 's/^#\(array\|cmath\|math\|_struct\|operator\|_random\|_collections\|itertools\|signal\|strop\|unicodedata\|_io\|_csv\|_md5\|_sha\|_sha256\|_sha512\|binascii\|select\|cStringIO\|time\|_functools\|_socket\|datetime\|_bisect\)\(.*\)/\1\2/' | $(SED) "s#\\(zlib[^\$$]*\\)\$$(prefix)\\([^\$$]*\\)\$$(exec_prefix)\\(.*\\)#\1$(DEVKITPRO)/portlibs/switch\2$(DEVKITPRO)/portlibs/switch\3#" >$(PYDIR)/Modules/Setup.dist
 	cp -r _nx-*/_nx $(PYDIR)/Modules/
 	
 	touch patchPY


### PR DESCRIPTION
Mac os build fails because default sed is unable to process some commands. 
Updated makefile uses gnu-sed on mac instead of default one.